### PR TITLE
p_race_mode conditions

### DIFF
--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -304,7 +304,7 @@ def p_submit_proof(params: AztecModelParams,
     process = state['current_process']
     updated_process: Optional[Process] = None
 
-    if process.phase == SelectionPhase.pending_reveal:
+    if process.phase == SelectionPhase.pending_rollup_proof:
         if process.duration_in_current_phase > params['phase_duration_rollup']:
             updated_process = copy(process)
             updated_process.phase = SelectionPhase.skipped # TODO: confirm


### PR DESCRIPTION
race_mode finalization does not need individual tx proofs to be public but needs a valid rollup proof published
In general, we can likely completely comment out the `proofs_are_public` condition, as it is either handled through a Prover Commitment Bond (which means whoever puts down bond has seen the individual tx proofs) or through Race Mode, where noone needs to show others the individual proofs as they don't coordinate Provers to help them rollup to one Rollup Proof. 
TLDR: Likely no more `proofs_are_public`, only care about valid rollup proof for now