### PR TITLE
Adding p_init_proposals policy function, with corresponding structure

### DIFF
--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -274,8 +274,10 @@ def p_init_proposals(params: AztecModelParams,
     """
     
     threshold = params["min_stake"]
-    eligible_users = list(filter(lambda x: x.staked_amount > threshold,
-                                 state["interacting_users"]))
+    eligible_users = list(filter(lambda x: x.is_sequencer and (x.staked_amount > threshold),
+                                 state["interacting_users"])) 
+    
+    #NOTE: I've written the above to work with either a specific Sequencer or a more general User class.
 
     for user in eligible_users:
         user.new_score() #Update each user's score parameter individually.
@@ -288,7 +290,6 @@ def p_init_proposals(params: AztecModelParams,
                      user in sorted_eligible_users[0:num_proposals_to_create]] #Create new proposals.
 
     return {"proposals_created": new_proposals}
-
 
 
 def p_init_process(params: AztecModelParams,

--- a/aztec_gddt/types.py
+++ b/aztec_gddt/types.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from enum import IntEnum, Enum, auto
 from math import floor
 
+import uuid
+
 # Units
 
 L1Blocks = Annotated[int, 'blocks']  # Number of L1 Blocks (time dimension)
@@ -100,7 +102,7 @@ class Process:
     finalization_tx_is_submitted: bool = False
     process_aborted: bool = False
     #TODO: Think about having "global" param for minimum stake in here to make it dynamically updateable per L2 block 
-    #NOTE: Currently I have placed this minimum stake in the AztecModelParam class. - Oct
+    #NOTE: Currently I have placed this minimum stake in the AztecModelParam class. - Ock
 
     def __add__(self, other):
         """
@@ -166,7 +168,7 @@ class Sequencer():  # XXX
         Function for generating a proposal based on current information. 
         """ 
         new_proposal = Proposal(uuid = uuid.uuid(),
-                                proposer_id = self.uuid,
+                                proposer_uuid = self.uuid,
                                 score = self.score,
                                 submission_time = current_state.time_l1,
                                 gas = 1,
@@ -174,7 +176,7 @@ class Sequencer():  # XXX
                                 )
         
 
-        #TODO: discuss logic of uuid, gas, and size. -Oct
+        #TODO: discuss logic of uuid, gas, and size. -Ock
 
         return new_proposal
 
@@ -198,7 +200,7 @@ class Proposal():
     submission_time: ContinuousL1Blocks
     gas: float
     size: float
-    from_proof_race: bool = False
+    from_proof_race: bool = False #Was this proposal created in the proof race?
 
     #TODO: add bond_uiid: /generaluserUUID
     #TODO: before, we only needed to track proposals, as that was the only way a block came into existence. 


### PR DESCRIPTION
This addresses the p_init_proposal policy function addressed in Issue #24 , along with boilerplate code to support either a general `User` class that can have `is_sequencer` flags, or a dedicated `Sequencer` class. 