### PR TITLE
Ock/feb 14 24/fix/prover bond amount issue

### DIFF
--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -351,7 +351,7 @@ def p_commit_bond(params: AztecModelParams,
     advance_blocks = 0
     transfers: list[Transfer] = []
 
-    commit_bond_amount_from_params = params['commit_bond_amount']
+    bond_amount = params['commit_bond_amount']
 
     if process is None:
         pass
@@ -388,20 +388,20 @@ def p_commit_bond(params: AztecModelParams,
                         gas: Gas = params['gas_estimators'].commitment_bond(state)
                         fee = gas * state['gas_fee_l1']
                         proposal_uuid = updated_process.tx_winning_proposal
+                        bond_amount = commit_bond_amount_from_params  
+
 
                         if bernoulli_trial(params['proving_marketplace_usage_probability']) is True:
                             provers: list[AgentUUID] = [
                                                         a_id 
                                                         for (a_id, a) 
                                                         in state['agents'].items() 
-                                                        if a.is_prover]
+                                                        if a.is_prover and a.balance > bond_amount]
                             # XXX: relays are going to be uniformly sampled
                             prover: AgentUUID = choice(provers)
-                            bond_amount = commit_bond_amount_from_params  
          
                         else:
                             prover = updated_process.leading_sequencer
-                            bond_amount = commit_bond_amount_from_params 
 
                         tx = CommitmentBond(who=updated_process.leading_sequencer,
                                             when=state['time_l1'],

--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -402,7 +402,7 @@ def p_commit_bond(params: AztecModelParams,
                         else:
                             prover = updated_process.leading_sequencer
 
-                        tx = CommitmentBond(who=updated_process.leading_sequencer,
+                        tx = CommitmentBond(who=prover,
                                             when=state['time_l1'],
                                             uuid=uuid4(),
                                             gas=gas,

--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -388,7 +388,6 @@ def p_commit_bond(params: AztecModelParams,
                         gas: Gas = params['gas_estimators'].commitment_bond(state)
                         fee = gas * state['gas_fee_l1']
                         proposal_uuid = updated_process.tx_winning_proposal
-                        bond_amount = commit_bond_amount_from_params  
 
 
                         if bernoulli_trial(params['proving_marketplace_usage_probability']) is True:

--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -397,11 +397,11 @@ def p_commit_bond(params: AztecModelParams,
                                                         if a.is_prover]
                             # XXX: relays are going to be uniformly sampled
                             prover: AgentUUID = choice(provers)
-                            bond_amount = commit_bond_amount_from_params  # TODO: open question - parametrize
-                            #TODO: transfer from Prover to bond_amount? OR just track and slash Prover? 
+                            bond_amount = commit_bond_amount_from_params  
+         
                         else:
                             prover = updated_process.leading_sequencer
-                            bond_amount = commit_bond_amount_from_params  # TODO: open question - parametrize
+                            bond_amount = commit_bond_amount_from_params 
 
                         tx = CommitmentBond(who=updated_process.leading_sequencer,
                                             when=state['time_l1'],

--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -396,7 +396,7 @@ def p_commit_bond(params: AztecModelParams,
                                                         a_id 
                                                         for (a_id, a) 
                                                         in state['agents'].items() 
-                                                        if a.is_prover and a.balance > bond_amount]
+                                                        if a.is_prover and a.balance >= bond_amount]
                             # XXX: relays are going to be uniformly sampled
                             prover: AgentUUID = choice(provers)
          

--- a/aztec_gddt/params.py
+++ b/aztec_gddt/params.py
@@ -9,7 +9,7 @@ N_INITIAL_AGENTS = 3
 
  # XXX
 INITIAL_AGENTS: list[Agent] = [Agent(uuid=uuid4(),
-                                     balance=max(norm.rvs(5, 2), 1),
+                                     balance=max(norm.rvs(50, 20), 1),
                                      is_sequencer=True,
                                      is_prover=True,
                                      is_relay=False,


### PR DESCRIPTION
Addresses #91 , requiring that a Prover has sufficient balance for the commitment bond. 

- Logic checks to see if balance is large enough
- Default agents now have amounts that are compatible with commitment bond parameter. 
