### PR TITLE
-switched sequencer for prover when committing proof

### DIFF
--- a/aztec_gddt/logic.py
+++ b/aztec_gddt/logic.py
@@ -654,7 +654,10 @@ def p_submit_proof(
                     advance_blocks = remaining_time
                     updated_process.phase = SelectionPhase.finalized
                     updated_process.duration_in_current_phase = 0
-                    who = updated_process.leading_sequencer  # XXX TODO: prover, not sequencer
+                    commit_bond_id = updated_process.tx_commitment_bond
+                    commit_bond: CommitmentBond = transactions.get(
+                    commit_bond_id, None)  # type: ignore
+                    who = commit_bond.prover_uuid  
                     gas: Gas = params['gas_estimators'].rollup_proof(
                         state)  # TODO: Check?
                     fee: Gwei = gas * state['gas_fee_l1']


### PR DESCRIPTION
- priorly, sequencer made rollup_proof transaction
- switched now by pulling prover_uuid from commitbond 